### PR TITLE
[FIX] Missing field "pap" when running a job

### DIFF
--- a/cortex4py/controllers/analyzers.py
+++ b/cortex4py/controllers/analyzers.py
@@ -48,11 +48,13 @@ class AnalyzersController(AbstractController):
 
     def run_by_id(self, analyzer_id, observable, **kwargs) -> Job:
         tlp = observable.get('tlp', 2)
+        pap = observable.get('pap', 2)
         data_type = observable.get('dataType', None)
 
         post = {
             'dataType': data_type,
-            'tlp': tlp
+            'tlp': tlp,
+            'pap': pap
         }
 
         params = {}


### PR DESCRIPTION
Without this fix, the pap field is always considered as AMBER for Cortex