### PR TITLE
analyzer: Allow for data to be provided

### DIFF
--- a/cortex4py/controllers/analyzers.py
+++ b/cortex4py/controllers/analyzers.py
@@ -68,11 +68,19 @@ class AnalyzersController(AbstractController):
                 post[key] = observable.get(key, None)
 
         if observable.get('dataType') == "file":
-            file_path = observable.get('data', None)
-            file_def = {
-                "data": (os.path.basename(file_path), open(file_path, 'rb'),
-                         magic.Magic(mime=True).from_file(file_path))
-            }
+            data = observable.get('data', None)
+            if observable.get('dataProvided') == True:
+                file_name = observable.get('parameters', {}).get('filename')
+                file_def = {
+                    "data": (os.path.basename(file_name), data,
+                            magic.Magic(mime=True).from_buffer(data))
+                }
+            else:
+                file_path = data
+                file_def = {
+                    "data": (os.path.basename(file_path), open(file_path, 'rb'),
+                            magic.Magic(mime=True).from_file(file_path))
+                }
 
             data = {
                 '_json': json.dumps(post)


### PR DESCRIPTION
If the user has the file content in a buffer it is more efficient to be
able to hand it to the analyzer directly instead of writing it out into
a temporary file just to be read back in again by the requests module.
Add an observable key 'dataProvided' which can be set to True to change
behaviour of run_by_id() and in turn run_by_name() so it uses the 'data'
key as observable data directly instead of interpreting it as a file
name and opening that file.

I didn't want to change behaviour for compatibility which is why I added that new flag key 'dataProvided'. I don't much like it though and would be happy to implement any other logic that'd be acceptable, e.g. using isinstance() to detect if 'data' is a file-like.

I plan to use this functionality here: https://github.com/michaelweiser/PeekabooAV/blob/cf02ed3a891058c669fe8e54b35d352f197f617e/peekaboo/toolbox/cortex.py#L152