### PR TITLE
Ensure the typing package is installed only if needed (python < 3.5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,12 @@ except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
     read_md = lambda f: open(f, 'r').read()
 
+install_requires = [
+    'typing;python_version<"3.5"',
+    'requests',
+    'python-magic'
+]
+
 setup(
     name='cortex4py',
     version='2.1.0',
@@ -33,5 +39,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     include_package_data=True,
-    install_requires=['typing', 'requests', 'python-magic']
+    install_requires=install_requires
 )


### PR DESCRIPTION
This prevents problems when installing cortex4py in recent python versions, where typing is installed as an external package, while there is a typing module included in the stdlib.

The external package then "shadows" the stdlib module, breaking other packages that use/rely on typing (when using cortex4py in a project with more dependencies)

I've used the suggested "incantation" to set up typing as a required dependency from the project site, here:

https://pypi.org/project/typing/

"For package maintainers, it is preferred to use typing;python_version<"3.5" if your package requires it to support earlier Python versions. This will avoid shadowing the stdlib typing module when your package is installed via pip install -t . on Python 3.5 or later."

Tested locally with python 3.7, 3.8 and 3.9